### PR TITLE
reactive subordinates should use venv

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,4 @@
+repo: git@github.com:juju-solutions/layer-filebeat.git
 includes:
   - 'layer:beats-base'
 options:

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,4 @@
-repo: git@github.com:juju-solutions/layer-filebeat.git
+repo: https://github.com/juju-solutions/layer-filebeat.git
 includes:
   - 'layer:beats-base'
 options:

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,2 +1,5 @@
 includes:
   - 'layer:beats-base'
+options:
+  basic:
+    use_venv: true


### PR DESCRIPTION
I ran into an issue today where my layer-apache-hadoop-namenode was using a newer version of charms.reactive than the filebeat charm in the store.

The filebeat charm stomped on my namenode's installation of charms.reactive.  To prevent this, please update filebeat to use a venv so filebeat's python stuffs don't stomp the principal.

FYI, this is the error I got due to conflicting charms.reactive modules:

http://paste.ubuntu.com/15801060/