### PR TITLE
Adding config to topmost layer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,12 @@
 options:
+  install_sources:
+    type: string
+    default: deb http://packages.elastic.co/beats/apt stable main
+    description: apt repository to fetch beats from
+  install_keys:
+    type: string
+    default: D88E42B4
+    description: repository key
   logpath:
     type: string
     default: "/var/log/*.log /var/log/*/*.log"

--- a/reactive/filebeat.py
+++ b/reactive/filebeat.py
@@ -1,9 +1,9 @@
+import charms.apt
 from charms.reactive import when
+from charms.reactive import when_any
 from charms.reactive import when_not
 from charms.reactive import set_state
 from charms.reactive import remove_state
-from charms.reactive import is_state
-
 
 from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.host import service_restart
@@ -14,37 +14,29 @@ from elasticbeats import enable_beat_on_boot
 from elasticbeats import push_beat_index
 
 
-@when('beats.repo.available')
-@when_not('filebeat.installed')
+@when_not('apt.installed.filebeat')
 def install_filebeat():
     status_set('maintenance', 'Installing filebeat')
-    apt_install(['filebeat'], fatal=True)
-    set_state('filebeat.installed')
+    charms.apt.queue_install(['filebeat'])
 
 
 @when('beat.render')
+@when_any('elasticsearch.available', 'logstash.available')
 def render_filebeat_template():
     render_without_context('filebeat.yml', '/etc/filebeat/filebeat.yml')
     remove_state('beat.render')
-    if is_state('elasticsearch.available') or is_state('logstash.available'):
-        service_restart('filebeat')
+    service_restart('filebeat')
     status_set('active', 'Filebeat ready')
 
 
-@when('config.changed.install_sources')
-@when('config.changed.install_keys')
-def reinstall_filebeat():
-        remove_state('filebeat.installed')
-
-
-@when('filebeat.installed')
+@when('apt.installed.filebeat')
 @when_not('filebeat.autostarted')
 def enlist_packetbeat():
     enable_beat_on_boot('filebeat')
     set_state('filebeat.autostarted')
 
 
-@when('filebeat.installed')
+@when('apt.installed.filebeat')
 @when('elasticsearch.available')
 @when_not('filebeat.index.pushed')
 def push_filebeat_index(elasticsearch):


### PR DESCRIPTION
The builder seemed to drop the keys if they were not in this top most
layer, i suppose this is due to the merge. So simply forward port them
into the topmost beat layer.

Refactors reactive/filebeat.py to not rely on the older states of
beat.repo.available and filebeat.installed

https://github.com/juju-solutions/layer-beats-base/issues/4