### PR TITLE
Fix filebeat hosts generation block

### DIFF
--- a/templates/filebeat.yml
+++ b/templates/filebeat.yml
@@ -19,9 +19,9 @@ output:
 {% if logstash %}
   logstash:
     hosts:
-      {% for host in logstash %}
+      {% for host in logstash -%}
       - "{{ host }}"
-      {% endfor -%}
+      {% endfor %}
     worker: 1
     compression_level: 3
     loadbalance: true


### PR DESCRIPTION
Without this change the line after the hosts block will get indented and the application will throw a yaml parser error on startup: `Loading config file error: YAML config parsing failed on /etc/filebeat/filebeat.yml: yaml: line 22: did not find expected '-' indicator. Exiting.`

`/etc/filebeat/filebeat.yml` generated before change:
    
    # WARNING! This file is managed by Juju. Edits will not persist.
    # Edit at your own risk
    filebeat:
      prospectors:
        -
          paths:
            - /var/log/*.log
            
          input_type: log
          exclude_files: [".gz$"]
          scan_frequency: 10s
          harvester_buffer_size: 16384
          max_bytes: 10485760.0
      registry_file: /var/lib/filebeat/registry
    logging:
      to_syslog: true
    output:

      logstash:
        hosts:
          
          - "172.16.0.133:5044"
          worker: 1
        compression_level: 3
        loadbalance: true



    shipper:
      name: nova-compute/1

Note the indentation after the hosts block.

File generated after change:

    # WARNING! This file is managed by Juju. Edits will not persist.
    # Edit at your own risk
    filebeat:
      prospectors:
        -
          paths:
            - /var/log/*.log
            
          input_type: log
          exclude_files: [".gz$"]
          scan_frequency: 10s
          harvester_buffer_size: 16384
          max_bytes: 10485760.0
      registry_file: /var/lib/filebeat/registry
    logging:
      to_syslog: true
    output:

      logstash:
        hosts:
          - "172.16.0.133:5044"
          
        worker: 1
        compression_level: 3
        loadbalance: true



    shipper:
      name: nova-compute/0