### PR TITLE
Add exclude_* config options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,3 +23,11 @@ options:
     type: int
     default: 10485760
     description: Maximum number of bytes a single log event can have. Default 10MB
+  exclude_files:
+    type: string
+    default: '[".gz$"]'
+    description: A list of regular expressions to match the files that you want Filebeat to ignore. https://www.elastic.co/guide/en/beats/filebeat/5.3/configuration-filebeat-options.html#exclude-files
+  exclude_lines:
+    type: string
+    default: "[]"
+    description: A list of regular expressions to match the lines that you want Filebeat to exclude. https://www.elastic.co/guide/en/beats/filebeat/5.3/configuration-filebeat-options.html#exclude-lines

--- a/templates/filebeat.yml
+++ b/templates/filebeat.yml
@@ -8,7 +8,8 @@ filebeat:
         - {{ path }}
         {% endfor %}
       input_type: log
-      exclude_files: [".gz$"]
+      exclude_files: {{ exclude_files }}
+      exclude_lines: {{ exclude_lines }}
       scan_frequency: 10s
       harvester_buffer_size: {{ harvester_buffer_size }}
       max_bytes: {{ max_bytes }}


### PR DESCRIPTION
We found the requirement to set exclude_files since the logpath option is so broad.
I added exclude_lines because it seemed to fit.