### PR TITLE
Adding support for ‘fields’ in prospector config, to enable logstash …

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,3 +47,7 @@ options:
     type: string
     default: "[]"
     description: A list of regular expressions to match the lines that you want Filebeat to exclude. https://www.elastic.co/guide/en/beats/filebeat/5.3/configuration-filebeat-options.html#exclude-lines
+  fields:
+    type: string
+    default: ""
+    description: "Space seperated list of key:value that the prospector will assign as field to each beat"

--- a/templates/filebeat.yml
+++ b/templates/filebeat.yml
@@ -16,7 +16,7 @@ filebeat:
       {% if fields -%}
       fields: 
         {% for fieldvalue in fields -%}
-        {{ fieldvalue.split(':')[0] }}: {{ fieldvalue.split(':')[1] }}
+        {{ fieldvalue.split(':')[0] }}: {{ fieldvalue.split(':')[-1] }}
         {% endfor %}  
       {% endif %}      
   registry_file: /var/lib/filebeat/registry

--- a/templates/filebeat.yml
+++ b/templates/filebeat.yml
@@ -13,6 +13,12 @@ filebeat:
       scan_frequency: 10s
       harvester_buffer_size: {{ harvester_buffer_size }}
       max_bytes: {{ max_bytes }}
+      {% if fields -%}
+      fields: 
+        {% for fieldvalue in fields -%}
+        {{ fieldvalue.split(':')[0] }}: {{ fieldvalue.split(':')[1] }}
+        {% endfor %}  
+      {% endif %}      
   registry_file: /var/lib/filebeat/registry
 logging:
   {% if logging_to_syslog %}


### PR DESCRIPTION
I'm adding the ability to include 'fields' in the prospector config. For example
```
  fields: 
    document_type: mysqllog
```
would be achieved by having
```
fields: document_type:mysqllog
```
in the juju config. Unfortunately, i haven't been able to test charms locally, can someone test this for me?