### PR TITLE
added simple configuration option to support shipping logs from Kubernetes pods

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,3 +51,7 @@ options:
     type: string
     default: ""
     description: "Space seperated list of key:value that the prospector will assign as field to each beat"
+  kube_logs:
+    type: boolean
+    default: false
+    description: "Add a prospector to ship logs from Kubernetes pods"

--- a/templates/filebeat.yml
+++ b/templates/filebeat.yml
@@ -19,6 +19,23 @@ filebeat:
         {{ fieldvalue.split(':')[0] }}: {{ fieldvalue.split(':')[-1] }}
         {% endfor %}  
       {% endif %}      
+    {% if kube_logs -%}
+    -
+      paths:
+        - /var/log/containers/*.log
+      exclude_files: ["filebeat.*log", "kube.*log"]
+      scan_frequency: 10s
+      harvester_buffer_size: {{ harvester_buffer_size }}
+      max_bytes: {{ max_bytes }}
+      fields_under_root: true
+      symlinks: true
+      json.message_key: log
+      json.keys_under_root: true
+      json.add_error_key: true
+      multiline.pattern: '^\s'
+      multiline.match: after
+      document_type: kube-logs
+    {% endif %}
   registry_file: /var/lib/filebeat/registry
 logging:
   {% if logging_to_syslog %}

--- a/templates/filebeat.yml
+++ b/templates/filebeat.yml
@@ -34,7 +34,8 @@ filebeat:
       json.add_error_key: true
       multiline.pattern: '^\s'
       multiline.match: after
-      document_type: kube-logs
+      fields:
+        type: kube-logs
     {% endif %}
   registry_file: /var/lib/filebeat/registry
 logging:


### PR DESCRIPTION
Add a prospector specific for shipping logs from Kubernetes pods.

The prospector is needed as Kubernetes logs are formatted in json and are not picked up by the default prospector.