### PR TITLE
readme refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ next-generation Logstash Forwarder, Filebeat tails logs and quickly sends this
 information to Logstash for further parsing and enrichment or to Elasticsearch
 for centralized storage and analysis.
 
+
 ## Usage
 
 Filebeat can be added to any principal charm thanks to the wonders of being
@@ -22,26 +23,17 @@ log source along with the elk stack so we can visualize our log data.
 
 If you do not need log buffering and alternate transforms on data that is
 being shipped to ElasticSearch, you can simply deploy the 'beats-core' bundle
-which stands up Elasticsearch, Kibana, and the three known working Beats
-subordinate services.
+which stands up Elasticsearch, Kibana, and the known working Beats
+subordinate applications.
 
     juju deploy ~containers/bundle/beats-core
     juju deploy ubuntu
     juju add-relation filebeat:beats-host ubuntu
     juju add-relation topbeat:beats-host ubuntu
-    juju add-relation packetbeat:beats-host ubuntu
 
-### A note about the beats-host relationship
+### Changing what is shipped
 
-The Beats suite of charms leverage the implicit "juju-info" relation interface
-which is special and unique in the context of subordinates. This is what allows
-us to relate the beat to any host, but may have some display oddities in the
-juju-gui. Until this is resolved, it's recommended to relate beats to their
-principal services using the CLI
-
-### Changing whats being shipped
-
-by default, the Filebeat charm is setup to ship everything in:
+By default, the Filebeat charm is setup to ship everything in:
 
     /var/log/*/*.log
     /var/log/*.log
@@ -49,19 +41,20 @@ by default, the Filebeat charm is setup to ship everything in:
 
 If you'd rather target specific log files:
 
-    juju set-config filebeat logpath /var/log/mylog.log
+    juju config filebeat logpath /var/log/mylog.log
 
 
 ## Testing the deployment
 
-The services provide extended status reporting to indicate when they are ready:
+The applications provide extended status reporting to indicate when they are
+ready:
 
-    juju status --format=tabular
+    juju status
 
 This is particularly useful when combined with watch to track the on-going
 progress of the deployment:
 
-    watch -n 0.5 juju status --format=tabular
+    watch juju status
 
 The message for each unit will provide information about that unit's state.
 Once they all indicate that they are ready, you can navigate to the kibana
@@ -69,8 +62,9 @@ url and view the streamed log data from the Ubuntu host.
 
     juju status kibana --format=yaml | grep public-address
 
-  open http://&lt;kibana-ip&gt;/ in a browser and begin creating your dashboard
-  visualizations
+Navigate to http://&lt;kibana-ip&gt;/ in a browser and begin creating your
+dashboard visualizations.
+
 
 ## Scale Out Usage
 
@@ -80,11 +74,11 @@ indexers, you can add-units to elasticsearch.
     juju add-unit elasticsearch
 
 You can also increase in multiples, for example: To increase the number of
-Logstash parser/buffer/shipping services:
+Logstash parser/buffer/shipping units:
 
     juju add-unit -n 2 logstash
 
-To monitor additional hosts, simply relate the Filebeat subordinate
+To monitor additional hosts, simply relate the Filebeat subordinate:
 
     juju add-relation filebeat:beats-host my-charm
 
@@ -97,6 +91,7 @@ To monitor additional hosts, simply relate the Filebeat subordinate
 - George Kraft <george.kraft@canonical.com>
 - Rye Terrell <rye.terrell@canonical.com>
 - Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
+
 
 # Need Help?
 

--- a/reactive/filebeat.py
+++ b/reactive/filebeat.py
@@ -64,7 +64,7 @@ def render_filebeat_logstash_ssl_cert():
 
 @when('apt.installed.filebeat')
 @when_not('filebeat.autostarted')
-def enlist_packetbeat():
+def enlist_filebeat():
     enable_beat_on_boot('filebeat')
     set_state('filebeat.autostarted')
 


### PR DESCRIPTION
- Update some out-of-date language in the readme (`service` -> `application`, `set-config` -> `config`, etc).
- fix a typo in one of the handler names (s/packetbeat/filebeat).

This is in the edge channel at rev 10:

https://jujucharms.com/filebeat/10