### PR TITLE
use xenial for filebeat amulet tests

### DIFF
--- a/tests/10-deploy-with-logstash
+++ b/tests/10-deploy-with-logstash
@@ -6,8 +6,8 @@ import unittest
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.d = amulet.Deployment(series='trusty')
-        self.d.add('ubuntu', 'cs:trusty/ubuntu')
+        self.d = amulet.Deployment(series='xenial')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
         self.d.add('logstash', 'cs:~containers/trusty/logstash-5')
         self.d.add('filebeat')
         self.d.relate('filebeat:beats-host', 'ubuntu:juju-info')
@@ -23,6 +23,7 @@ class TestCharm(unittest.TestCase):
         stash_address = self.logstash.relation('beat', 'filebeat:logstash')['private-address']  # noqa
         config = self.filebeat.file_contents('/etc/filebeat/filebeat.yml')
         self.assertTrue(stash_address in config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/20-deploy-with-elasticsearch
+++ b/tests/20-deploy-with-elasticsearch
@@ -7,9 +7,9 @@ import time
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.d = amulet.Deployment(series='trusty')
-        self.d.add('ubuntu', 'cs:trusty/ubuntu')
-        self.d.add('elasticsearch', 'cs:trusty/elasticsearch-19')
+        self.d = amulet.Deployment(series='xenial')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
+        self.d.add('elasticsearch', 'cs:xenial/elasticsearch-25')
         self.d.add('filebeat')
         self.d.relate('filebeat:beats-host', 'ubuntu:juju-info')
         self.d.relate('filebeat:elasticsearch', 'elasticsearch:client')
@@ -38,6 +38,7 @@ class TestCharm(unittest.TestCase):
         self.assertTrue('/tmp/amulet.log' in config)
         self.assertTrue('9999' in config)
         self.assertTrue('10485761' in config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/30-deploy-with-logstash-hosts
+++ b/tests/30-deploy-with-logstash-hosts
@@ -8,7 +8,7 @@ class TestCharm(unittest.TestCase):
     def setUp(self):
         self.logstash_host = '192.168.0.1:5044'
         self.d = amulet.Deployment(series='xenial')
-        self.d.add('ubuntu', 'cs:ubuntu')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
         self.d.add('filebeat')
         self.d.relate('filebeat:beats-host', 'ubuntu:juju-info')
         self.d.configure('filebeat', {'logstash_hosts': self.logstash_host})
@@ -21,6 +21,7 @@ class TestCharm(unittest.TestCase):
     def test_logstash_host_in_templating(self):
         config = self.filebeat.file_contents('/etc/filebeat/filebeat.yml')
         self.assertTrue(self.logstash_host in config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/40-deploy-with-kafka
+++ b/tests/40-deploy-with-kafka
@@ -2,30 +2,30 @@
 
 import amulet
 import unittest
-import time
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.d = amulet.Deployment(series='trusty')
-        self.d.add('ubuntu', 'cs:trusty/ubuntu')
-        self.d.add('kafka', 'cs:trusty/kafka')
-        self.d.add('zookeeper', 'cs:trusty/zookeeper')
+        self.d = amulet.Deployment(series='xenial')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
+        self.d.add('kafka', 'cs:xenial/kafka')
+        self.d.add('zookeeper', 'cs:xenial/zookeeper')
         self.d.add('filebeat')
         self.d.relate('kafka', 'zookeeper')
         self.d.relate('filebeat:beats-host', 'ubuntu:juju-info')
-        self.d.relate('filebeat:elasticsearch', 'elasticsearch:client')
+        self.d.relate('filebeat:kafka', 'kafka:client')
 
         self.d.setup(timeout=1200)
         self.d.sentry.wait()
 
-        self.elasticsearch = self.d.sentry['kafka'][0]
+        self.kafka = self.d.sentry['kafka'][0]
         self.filebeat = self.d.sentry['filebeat'][0]
 
     def test_kafka_host_in_templating(self):
-        kafka_address = self.elasticsearch.relation('client', 'filebeat:kafka')['private-address']  # noqa
+        kafka_address = self.kafka.relation('client', 'filebeat:kafka')['private-address']  # noqa
         config = self.filebeat.file_contents('/etc/filebeat/filebeat.yml')
         self.assertTrue(kafka_address in config)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/50-deploy-with-kafka-hosts
+++ b/tests/50-deploy-with-kafka-hosts
@@ -8,7 +8,7 @@ class TestCharm(unittest.TestCase):
     def setUp(self):
         self.kafka_host = '192.168.0.1:5044'
         self.d = amulet.Deployment(series='xenial')
-        self.d.add('ubuntu', 'cs:ubuntu')
+        self.d.add('ubuntu', 'cs:xenial/ubuntu')
         self.d.add('filebeat')
         self.d.relate('filebeat:beats-host', 'ubuntu:juju-info')
         self.d.configure('filebeat', {'kafka_hosts': self.kafka_host})
@@ -21,6 +21,7 @@ class TestCharm(unittest.TestCase):
     def test_kafka_host_in_templating(self):
         config = self.filebeat.file_contents('/etc/filebeat/filebeat.yml')
         self.assertTrue(self.kafka_host in config)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Also drive-by fix in `tests/40-deploy-with-kafka`:

- s/elasticsearch/kafka since there is no elasticsearch charm in this test