### PR TITLE
update readme with new elk-stack namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Filebeat can be added to any principal charm thanks to the wonders of being
 a subordinate charm. The following usage example will deploy an ubuntu
 log source along with the elk stack so we can visualize our log data.
 
-    juju deploy ~containers/bundle/elk-stack
-    juju deploy ~containers/filebeat
-    juju deploy ubuntu
+    juju deploy ~elasticsearch-charmers/bundle/elk-stack
+    juju deploy xenial/filebeat
+    juju deploy xenial/ubuntu
     juju add-relation filebeat:beats-host ubuntu
     juju add-relation filebeat logstash
 
@@ -27,7 +27,7 @@ which stands up Elasticsearch, Kibana, and the known working Beats
 subordinate applications.
 
     juju deploy ~containers/bundle/beats-core
-    juju deploy ubuntu
+    juju deploy xenial/ubuntu
     juju add-relation filebeat:beats-host ubuntu
     juju add-relation topbeat:beats-host ubuntu
 


### PR DESCRIPTION
The elk-stack has moved to the ~elasticsearch-charmers namespace. Update the readme usage to reflect that, and make sure we instruct people to use xenial charms.