### PR TITLE
render the ssl certs on install/update

### DIFF
--- a/reactive/filebeat.py
+++ b/reactive/filebeat.py
@@ -34,6 +34,7 @@ def install_filebeat():
     })
 def render_filebeat_template():
     connections = render_without_context('filebeat.yml', '/etc/filebeat/filebeat.yml')
+    render_filebeat_logstash_ssl_cert()
     remove_state('beat.render')
     if connections:
         status_set('active', 'Filebeat ready.')


### PR DESCRIPTION
The ssl certs are not being created at install time due to the render_filebeat_template() function being called first and then changing the state so the render_filebeat_logstash_ssl_cert() function will not be called.

This change ensures that whenever the render_filebeat_template() function re-renders the config file it also re-renders the certs, ensuring they are correctly created at install time