### PR TITLE
fix kube_logs config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   install_sources:
     type: string
-    default: deb http://packages.elastic.co/beats/apt stable main
+    default: deb https://artifacts.elastic.co/packages/5.x/apt stable main
     description: apt repository to fetch beats from
   install_keys:
     type: string

--- a/templates/filebeat.yml
+++ b/templates/filebeat.yml
@@ -32,9 +32,14 @@ filebeat:
       max_bytes: {{ max_bytes }}
       fields_under_root: true
       symlinks: true
-      json.message_key: log
-      json.keys_under_root: true
-      json.add_error_key: true
+      # NB: disable json decoding; setting any of these would result in the
+      # top 'message' key being removed, thereby breaking things like the
+      # graylog beats input. Consumers will need to do their own json decoding
+      # for now.
+      # - https://github.com/juju-solutions/layer-filebeat/issues/44
+      #json.message_key: log
+      #json.keys_under_root: true
+      #json.add_error_key: true
       multiline.pattern: '^\s'
       multiline.match: after
       fields:


### PR DESCRIPTION
+ use filebeat-5.x
kube_logs sets filebeat to look at the /var/log/containers/*.log directory,
which contains symlinks to the docker container logs. Filebeat does not
support the 'symlinks' config until v5. Update our config to grab the 5.x
version of filebeat. This brings us in-line with the same repo used for
the rest of the ELK stack.

+ disable json decoding
Docker spits out json logs by default. Filebeat decodes json in a manner
that is incompatible with the graylog beats input. Disable json decoding
until upstream resolves this.

Fixes #44.