### PR TITLE
utilize common config and cleanup template spacing 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,10 +11,6 @@ options:
     type: string
     default: "/var/log/*.log /var/log/*/*.log"
     description: "Space separated log paths to monitor. Can contain wildcards."
-  logging_to_syslog:
-    type: boolean
-    default: true
-    description: "Send filebeat logs to syslog: https://www.elastic.co/guide/en/beats/filebeat/6.7/configuration-logging.html#_literal_logging_to_syslog_literal"
   harvester_buffer_size:
     type: int
     default: 16384

--- a/templates/filebeat-5.yml
+++ b/templates/filebeat-5.yml
@@ -51,6 +51,7 @@ logging:
   {% if logging_to_syslog -%}
   to_syslog: true
   {%- endif %}
+  level: {{ log_level }}
   metrics.enabled: false
 
 output:

--- a/templates/filebeat-6.yml
+++ b/templates/filebeat-6.yml
@@ -7,7 +7,7 @@ filebeat:
       paths:
         {% for path in logpath -%}
         - {{ path }}
-        {%- endfor %}
+        {% endfor %}
       symlinks: false
       exclude_files: {{ exclude_files }}
       exclude_lines: {{ exclude_lines }}
@@ -23,7 +23,7 @@ filebeat:
         {% if fields -%}
         {% for fieldvalue in fields -%}
         {{ fieldvalue.split(':')[0] }}: {{ fieldvalue.split(':')[-1] }}
-        {%- endfor %}
+        {% endfor %}
         {%- endif %}
     {% if kube_logs -%}
     - type: docker
@@ -51,8 +51,8 @@ logging:
   {% if logging_to_syslog -%}
   to_syslog: true
   {%- endif %}
+  level: {{ log_level }}
   metrics.enabled: false
-  level: debug
 
 output:
 {% if logstash or logstash_hosts %}


### PR DESCRIPTION
With https://github.com/juju-solutions/layer-beats-base/pull/33, we moved logging config into the beats base layer.  Update our config to match, and fixup the v6 template spacing.