### PR TITLE
template updates

### DIFF
--- a/reactive/filebeat.py
+++ b/reactive/filebeat.py
@@ -67,7 +67,9 @@ def render_filebeat_template():
         status.maint('Waiting for: {}'.format(KUBE_CONFIG))
         return
 
-    version = charms.apt.get_package_version('filebeat')[0]
+    # The v5 template is compatible with all versions < 6
+    major = charms.apt.get_package_version('filebeat')[0]
+    version = major if major.isdigit() and int(major) > 5 else "5"
     cfg_original_hash = file_hash(FILEBEAT_CONFIG)
     connections = render_without_context(
         'filebeat-{}.yml'.format(version),

--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -2,7 +2,7 @@
 # Edit at your own risk
 filebeat:
   registry_file: /var/lib/filebeat/registry
-  prospectors:
+  inputs:
     - type: log
       paths:
         {% for path in logpath -%}


### PR DESCRIPTION
- use v5 template for filebeat < 6 (or any unknown version)
- s/inputs/prospectors in v6 template. 'inputs' was added after 6.2.0 but is invalid before 6.3.0. 'prospectors' appears valid for all v6.x releases.
- add v7 template

Fixes #71 