### PR TITLE
Logrotate filebeat.log with copytruncate

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,9 +1,18 @@
 repo: https://github.com/juju-solutions/layer-filebeat.git
 includes:
   - 'layer:beats-base'
+  - 'layer:logrotate'
 options:
   apt:
     packages:
       - filebeat
     version_package: filebeat
     full_version: True
+  logrotate:
+    /var/log/filebeat.log:
+      - copytruncate
+      - rotate 4
+      - weekly
+      - compress
+      - missingok
+


### PR DESCRIPTION
Apparently logrotate can't properly handle when its own logfile gets
rotated.
This should fix it.