### PR TITLE
Allow for injection of arbitrary inputs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,3 +42,8 @@ options:
       Whether or not to include the Kubernetes audit log as well as any K8s metadata
       when container logs are present on the system:
       https://www.elastic.co/guide/en/beats/filebeat/6.7/add-kubernetes-metadata.html
+  extra_inputs:
+    type: string
+    default: ""
+    description: |
+      A YAML list which will be injected to define additional prospectors/inputs.

--- a/templates/filebeat-5.yml
+++ b/templates/filebeat-5.yml
@@ -49,6 +49,9 @@ filebeat:
       fields:
         type: kube-logs
     {% endif %}
+    {% if extra_inputs -%}
+    {{ extra_inputs|indent(4) }}
+    {% endif %}
   registry_file: /var/lib/filebeat/registry
 
 logging:

--- a/templates/filebeat-6.yml
+++ b/templates/filebeat-6.yml
@@ -56,6 +56,9 @@ filebeat:
           kube_config: /root/.kube/config
       {%- endif %}
     {%- endif %}
+    {% if extra_inputs -%}
+    {{ extra_inputs|indent(4) }}
+    {% endif %}
 
 logging:
   {% if logging_to_syslog -%}

--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -56,6 +56,9 @@ filebeat:
           kube_config: /root/.kube/config
       {%- endif %}
     {%- endif %}
+    {% if extra_inputs -%}
+    {{ extra_inputs|indent(4) }}
+    {% endif %}
 
 logging:
   {% if logging_to_syslog -%}


### PR DESCRIPTION
The extra_inputs config value, if specified, will inject a YAML blob
into the filebeat configuration.  This allows both for specifying
additional inputs beyond the 1-2 generated directly by the charm, and
allows for customizations specific to those additional inputs, e.g.
multiline capture settings.