### PR TITLE
update k8s metadata guard

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,6 +42,8 @@ options:
       Whether or not to include the Kubernetes audit log as well as any K8s metadata
       when container logs are present on the system:
       https://www.elastic.co/guide/en/beats/filebeat/6.7/add-kubernetes-metadata.html
+
+      Note: this option has no effect when related to a non Charmed Kubernetes charm.
   extra_inputs:
     type: string
     default: ""

--- a/templates/filebeat-5.yml
+++ b/templates/filebeat-5.yml
@@ -7,7 +7,7 @@ filebeat:
         {% for path in logpath -%}
         - {{ path }}
         {% endfor %}
-        {% if kube_logs -%}
+        {% if has_k8s -%}
         - /root/cdk/audit/*.log
         {%- endif %}
       input_type: log

--- a/templates/filebeat-6.yml
+++ b/templates/filebeat-6.yml
@@ -8,7 +8,7 @@ filebeat:
         {% for path in logpath -%}
         - {{ path }}
         {% endfor %}
-        {% if kube_logs -%}
+        {% if has_k8s -%}
         - /root/cdk/audit/*.log
         {%- endif %}
       symlinks: false
@@ -50,7 +50,7 @@ filebeat:
         {{ fieldvalue.split(':')[0] }}: {{ fieldvalue.split(':')[-1] }}
         {% endfor %}
         {%- endif %}
-      {% if kube_logs -%}
+      {% if has_k8s -%}
       processors:
       - add_kubernetes_metadata:
           in_cluster: false

--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -8,7 +8,7 @@ filebeat:
         {% for path in logpath -%}
         - {{ path }}
         {% endfor %}
-        {% if kube_logs -%}
+        {% if has_k8s -%}
         - /root/cdk/audit/*.log
         {%- endif %}
       symlinks: false
@@ -49,7 +49,7 @@ filebeat:
         {{ fieldvalue.split(':')[0] }}: {{ fieldvalue.split(':')[-1] }}
         {% endfor %}
         {%- endif %}
-      {% if kube_logs -%}
+      {% if has_k8s -%}
       processors:
       - add_kubernetes_metadata:
           in_cluster: false


### PR DESCRIPTION
Partial fix for https://bugs.launchpad.net/filebeat-charm/+bug/1858668

Depends on https://github.com/juju-solutions/layer-beats-base/pull/36

Use the new `has_k8s` guard for our k8s metadata processor. This ensures relevant template bits are only rendered if both `kube_logs=True` **and** `/root/.kube/config` exists.