### PR TITLE
Update metadata to indicate focal support

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,3 +10,4 @@ series:
   - xenial
   - trusty
   - bionic
+  - focal


### PR DESCRIPTION
Adding focal to the supported series as filebeat is available in the
required (default) repo.