### PR TITLE
Fix filebeat.yml template for version 7.x

### DIFF
--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -1,7 +1,7 @@
 # WARNING! This file is managed by Juju. Edits will not persist.
 # Edit at your own risk
 filebeat:
-  registry_file: /var/lib/filebeat/registry
+  filebeat.registry.path: /var/lib/filebeat/registry
   inputs:
     - type: log
       paths:

--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -1,7 +1,7 @@
 # WARNING! This file is managed by Juju. Edits will not persist.
 # Edit at your own risk
 filebeat:
-  filebeat.registry.path: /var/lib/filebeat/registry
+  registry.path: /var/lib/filebeat/registry
   inputs:
     - type: log
       paths:


### PR DESCRIPTION
Starting with version 7.0, Filebeat stores the registry in a sub-directory. The directory is configured using the **filebeat.registry.path** setting. 

This commit makes sure correct settings are used when installing filebeat 7.x.