### PR TITLE
support using TLS only as transport 

### DIFF
--- a/templates/filebeat-5.yml
+++ b/templates/filebeat-5.yml
@@ -78,8 +78,10 @@ output:
     worker: 1
     compression_level: 3
     loadbalance: true
-    {% if logstash_ssl_cert and logstash_ssl_key -%}
+    {% if logstash_ssl_cert -%}
     ssl.certificate_authorities: ["/etc/ssl/certs/filebeat-logstash.crt"]
+    {%- endif %}
+    {% if logstash_ssl_cert and logstash_ssl_key -%}
     ssl.certificate: "/etc/ssl/certs/filebeat-logstash.crt"
     ssl.key: "/etc/ssl/private/filebeat-logstash.key"
     {%- endif %}

--- a/templates/filebeat-6.yml
+++ b/templates/filebeat-6.yml
@@ -89,8 +89,10 @@ output:
     worker: 1
     compression_level: 3
     loadbalance: true
-    {% if logstash_ssl_cert and logstash_ssl_key -%}
+    {% if logstash_ssl_cert -%}
     ssl.certificate_authorities: ["/etc/ssl/certs/filebeat-logstash.crt"]
+    {%- endif %}
+    {% if logstash_ssl_cert and logstash_ssl_key -%}
     ssl.certificate: "/etc/ssl/certs/filebeat-logstash.crt"
     ssl.key: "/etc/ssl/private/filebeat-logstash.key"
     {%- endif %}

--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -84,8 +84,10 @@ output:
     worker: 1
     compression_level: 3
     loadbalance: true
-    {% if logstash_ssl_cert and logstash_ssl_key -%}
+    {% if logstash_ssl_cert -%}
     ssl.certificate_authorities: ["/etc/ssl/certs/filebeat-logstash.crt"]
+    {%- endif %}
+    {% if logstash_ssl_cert and logstash_ssl_key -%}
     ssl.certificate: "/etc/ssl/certs/filebeat-logstash.crt"
     ssl.key: "/etc/ssl/private/filebeat-logstash.key"
     {%- endif %}


### PR DESCRIPTION
This change to the templates is to allow connecting to logstash using TLS, but not using the cert/key pair to do mutual authentication.