### PR TITLE
Add charmhub integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ To monitor additional applications, simply relate the filebeat subordinate:
 
     juju add-relation filebeat:beats-host my-charm
 
+
+## Build and publish new versions
+
+This charm uses the reactive framework. `charm build` is used to build a deployable charm.
+
+In order to publish new versions of the charm, the following commands need to be run:
+
+```
+charm build
+cd /tmp/charm-builds/filebeat
+charmcraft pack
+charmcraft upload filebeat_ubuntu-20.04-amd64_ubuntu-18.04-amd64_ubuntu-16.04-amd64.charm
+charmcraft release filebeat --revision=34 --channel=edge
+charmcraft status filebeat
+```
+
 ## Contact Information
 
 - <elasticsearch-charmers@lists.launchpad.net>

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,38 @@
+type: charm
+
+parts:
+  charm:
+    plugin: dump
+    source: .
+    prime:
+      - actions/*
+      - actions.yaml
+      - bin/*
+      - config.yaml
+      - copyright
+      - hooks/*
+      - icon.svg
+      - lib/*
+      - LICENSE
+      - metadata.yaml
+      - reactive/*
+      - README.md
+      - templates/*
+      - wheelhouse/*
+      - wheelhouse.txt
+
+bases:
+    - build-on:
+        - name: ubuntu
+          channel: "20.04"
+          architectures: ["amd64"]
+      run-on:
+        - name: ubuntu
+          channel: "20.04"
+          architectures: ["amd64"]
+        - name: ubuntu
+          channel: "18.04"
+          architectures: ["amd64"]
+        - name: ubuntu
+          channel: "16.04"
+          architectures: ["amd64"]


### PR DESCRIPTION
`charmcraft status filebeat` shows the charm was mirrored from the old charmstore to be deployed on **all** architectures.

Since we don't have a charmhub build farm to support "charm build" + "charmcraft pack", the charm will be released for amd64 archs for now.

A version has been released in amd64/edge for xenial/bionic/focal, but the charm needs to be tested on xenial and bionic because "charm build" may have left built binaries incompatible with previous versions.