### PR TITLE
Add filebeat 7 support

### DIFF
--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -1,7 +1,6 @@
 # WARNING! This file is managed by Juju. Edits will not persist.
 # Edit at your own risk
 filebeat:
-  registry_file: /var/lib/filebeat/registry
   inputs:
     - type: log
       paths:


### PR DESCRIPTION
Beats version 7 has removed filebeat.registry_file setting [1]. To reflect this
change, registry_file variable is removed from filebeat-7.yml file to support
filebeat version 7. 

To verify the behavior of the change, I have run graylog functional test. The
log can be found [here](https://pastebin.ubuntu.com/p/bSHTs2DsMZ/).

[1] https://www.elastic.co/guide/en/beats/libbeat/current/release-notes-7.0.0.html