### PR TITLE
Revert "Fix filebeat.yml template for version 7.x"

### DIFF
--- a/templates/filebeat-7.yml
+++ b/templates/filebeat-7.yml
@@ -1,7 +1,7 @@
 # WARNING! This file is managed by Juju. Edits will not persist.
 # Edit at your own risk
 filebeat:
-  registry.path: /var/lib/filebeat/registry
+  registry_file: /var/lib/filebeat/registry
   inputs:
     - type: log
       paths:


### PR DESCRIPTION
Reverts juju-solutions/layer-filebeat#84.

Since we don't offer a way to configure this key and filebeat starts fine without it, let's just use the default.  Backing this out in favor of #92.