### PR TITLE
Ubuntu Jammy support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,21 @@ To monitor additional applications, simply relate the filebeat subordinate:
 
     juju add-relation filebeat:beats-host my-charm
 
+## Build and publish new versions
+
+This charm uses the reactive framework. `charm pack` is used to build a
+deployable charm. In order to publish new versions of the charm, the following
+commands need to be run:
+
+**Note:** Use appropriate revision number in `charmcraft release` command.
+
+```
+charmcraft pack
+charmcraft upload filebeat_ubuntu-22.04-amd64_ubuntu-20.04-amd64_ubuntu-18.04-amd64.charm
+charmcraft release filebeat --revision=34 --channel=edge
+charmcraft status filebeat
+```
+
 ## Contact Information
 
 - <elasticsearch-charmers@lists.launchpad.net>

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,32 @@
+# Learn more about charmcraft.yaml configuration at:
+# https://juju.is/docs/sdk/charmcraft-config
+# This is a template `charmcraft.yaml` file for reactive charms
+# This file is managed by bootstack-charms-spec and should not be modified
+# within individual charm repos. https://launchpad.net/bootstack-charms-spec
+
+type: charm
+
+parts:
+  charm:
+    source: ./
+    plugin: reactive
+    build-snaps: [ charm ]
+
+bases:
+  - build-on:
+    - name: ubuntu
+      channel: "20.04"
+      architectures: ["amd64"]
+    run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures:
+          - amd64
+      - name: ubuntu
+        channel: "20.04"
+        architectures:
+          - amd64
+      - name: ubuntu
+        channel: "18.04"
+        architectures:
+          - amd64

--- a/reactive/filebeat.py
+++ b/reactive/filebeat.py
@@ -6,7 +6,6 @@ from charms.reactive import set_state
 from charms.reactive import remove_state
 from charms.reactive import hook
 from charms.reactive.helpers import data_changed
-from charms.templating.jinja2 import render
 
 from charmhelpers.core import unitdata
 from charmhelpers.core.hookenv import config, log
@@ -108,13 +107,13 @@ def manage_filebeat_logstash_ssl():
         key = base64.b64decode(logstash_ssl_key).decode('utf8')
 
         if data_changed('logstash_cert', cert):
-            render(template='{{ data }}',
-                   context={'data': cert},
-                   target=LOGSTASH_SSL_CERT, perms=0o444)
+            with open(LOGSTASH_SSL_CERT, "w") as cert_file:
+                cert_file.write(cert)
+            os.chmod(LOGSTASH_SSL_CERT, 0o444)
         if data_changed('logstash_key', key):
-            render(template='{{ data }}',
-                   context={'data': key},
-                   target=LOGSTASH_SSL_KEY, perms=0o400)
+            with open(LOGSTASH_SSL_KEY, "w") as key_file:
+                key_file.write(key)
+            os.chmod(LOGSTASH_SSL_KEY, 0o400)
     else:
         if not logstash_ssl_cert and os.path.exists(LOGSTASH_SSL_CERT):
             os.remove(LOGSTASH_SSL_CERT)

--- a/templates/filebeat-6.yml
+++ b/templates/filebeat-6.yml
@@ -133,3 +133,9 @@ output:
 {% if juju_principal_unit -%}
 name: {{ juju_principal_unit }}
 {%- endif %}
+seccomp:
+  default_action: errno
+  syscalls:
+    - action: allow
+      names:
+        - clone3

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,0 @@
-charms.templating.jinja2>1.0.0,<=2.0.0ri  


### PR DESCRIPTION
**Dependency:** [This change to `layer:beats-base`](https://github.com/juju-solutions/layer-beats-base/pull/41) has to be merge as well for proper `Ubuntu 22.04` support (more info in the PR).

This change adds support for deployment of `filebeats` charm on `Ubuntu 22.04` and adds `charmcraft.yaml` file for build compatibility with `charmcraft`.

Two main changes were needed:
* Drop dependency on [charms.templating.jinja2](https://github.com/juju-solutions/charms.templating.jinja2) which depends on [Tempita](https://pypi.org/project/Tempita/) package that does not work on `python3.10` (More info in PR linked above)
* Add `clone3` syscall to list of allowed syscalls. Absence of this syscall caused an issues that are described in [this Github Issue](https://github.com/elastic/apm-server/issues/6238) (It's from `apm` project, not `filebeats` but the problem and the solution are the same)

Resolves #94