### PR TITLE
Remove series in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,8 +6,4 @@ description: |
   As the next-generation Logstash Forwarder, Filebeat tails logs and quickly
   sends this information to Logstash for further parsing and enrichment or to
   Elasticsearch for centralized storage and analysis.
-series:
-  - xenial
-  - trusty
-  - bionic
-  - focal
+series: []


### PR DESCRIPTION
The series in `metadata.yaml` file needs to be changed to `[]` to avoid conflicts with `charmcraft.yaml`.