### PR TITLE
Reinstate silently dropped Xenial (16.04) support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,3 +30,7 @@ bases:
         channel: "18.04"
         architectures:
           - amd64
+      - name: ubuntu
+        channel: "16.04"
+        architectures:
+          - amd64

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,3 @@
+# Include python requirements here
+# Xenial & py35 support - https://github.com/juju-solutions/layer-basic/pull/197
+MarkupSafe<2.0.0


### PR DESCRIPTION
It looks like Ubuntu Xenial (16.04) support was quietly dropped in commits https://github.com/juju-solutions/layer-filebeat/commit/564f6e5a0804ede2dad4eebad9082858a520db63 and https://github.com/juju-solutions/layer-filebeat/commit/8a9aef4dc5aac9ff0284902f72d9b6bd40ab80b0, but this series is still supported via ESM.

This PR will reinstate it via `charmcraft.yaml`, and also pins the `MarkupSafe` library to `<2.0.0` for `py35` compatibility (Xenial provides Python 3.5.2).